### PR TITLE
Connect with Battlefield 4 API to change LED color based on status

### DIFF
--- a/Phos.ScreenSync/MainWindow.xaml
+++ b/Phos.ScreenSync/MainWindow.xaml
@@ -49,14 +49,17 @@
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBox x:Name="Battlefield4UsernameInput" Width="200" Height="30" Margin="0,0,0,10" />
-                <Button x:Name="Battlefield4StartStopButton" Content="Start" Width="200" Height="30" Margin="0,0,0,10" Click="Battlefield4StartStopButton_Click" />
+                <StackPanel Grid.Row="0" Grid.Column="2">
+                    <TextBox x:Name="Battlefield4UsernameInput" Width="200" Height="30" Margin="0,0,0,10" />
+                    <Button x:Name="Battlefield4StartStopButton" Content="Start" Width="200" Height="30" Margin="0,0,0,10" Click="Battlefield4StartStopButton_Click" />
+                </StackPanel>
                 <TextBox x:Name="Battlefield4JsonOutput" Width="400" Height="200" Margin="0,0,0,10" IsReadOnly="True" VerticalScrollBarVisibility="Auto" />
             </Grid>
         </TabItem>

--- a/Phos.ScreenSync/MainWindow.xaml
+++ b/Phos.ScreenSync/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Phos.ScreenSync.MainWindow"
+<Window x:Class="Phos.ScreenSync.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -44,6 +44,21 @@
         </TabItem>
         <TabItem Header="Game integrations">
             <TextBlock>Hello World</TextBlock>
+        </TabItem>
+        <TabItem Header="Battlefield 4">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="Battlefield4UsernameInput" Width="200" Height="30" Margin="0,0,0,10" />
+                <Button x:Name="Battlefield4StartStopButton" Content="Start" Width="200" Height="30" Margin="0,0,0,10" Click="Battlefield4StartStopButton_Click" />
+                <TextBox x:Name="Battlefield4JsonOutput" Width="400" Height="200" Margin="0,0,0,10" IsReadOnly="True" VerticalScrollBarVisibility="Auto" />
+            </Grid>
         </TabItem>
     </TabControl>
 </Window>

--- a/Phos.ScreenSync/MainWindow.xaml.cs
+++ b/Phos.ScreenSync/MainWindow.xaml.cs
@@ -230,13 +230,16 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             var settings = _settingsManager.LoadSettings();
             var battlefieldApiUrl = settings?.BattlefieldApiUrl ?? string.Empty;
             var response = await httpClient.GetStringAsync($"{battlefieldApiUrl}{_battlefield4Username}");
-            Dispatcher.Invoke(() => Battlefield4JsonOutput.Text = response);
-
             var jsonDocument = JsonDocument.Parse(response);
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            var formattedJson = JsonSerializer.Serialize(jsonDocument, options);
+            Dispatcher.Invoke(() => Battlefield4JsonOutput.Text = formattedJson);
+
             var currentDeaths = jsonDocument.RootElement.GetProperty("deaths").GetInt32();
 
             if (currentDeaths > previousDeaths)
             {
+                Console.WriteLine("User has died");
                 // User has died, turn LED strip red for 1 second
                 await _connection.SendEvent(PhosSocketMessage.SetNetworkState, SelectedRooms.Select(r => r.Id).ToList(), new State { Colors = new List<string> { "#FF0000" } });
                 await Task.Delay(1000);

--- a/Phos.ScreenSync/MainWindow.xaml.cs
+++ b/Phos.ScreenSync/MainWindow.xaml.cs
@@ -227,7 +227,9 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
         while (_isPolling && !cancellationToken.IsCancellationRequested)
         {
-            var response = await httpClient.GetStringAsync($"https://api.bflist.io/bf4/v1/players/{_battlefield4Username}");
+            var settings = _settingsManager.LoadSettings();
+            var battlefieldApiUrl = settings?.BattlefieldApiUrl ?? string.Empty;
+            var response = await httpClient.GetStringAsync($"{battlefieldApiUrl}{_battlefield4Username}");
             Dispatcher.Invoke(() => Battlefield4JsonOutput.Text = response);
 
             var jsonDocument = JsonDocument.Parse(response);

--- a/Phos.ScreenSync/SettingsManager.cs
+++ b/Phos.ScreenSync/SettingsManager.cs
@@ -1,15 +1,21 @@
 ﻿using System.IO;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace Phos.ScreenSync;
 
 public class SettingsManager<T> where T : class
 {
     private readonly string _filePath;
+    private readonly IConfiguration _configuration;
 
     public SettingsManager(string fileName)
     {
         _filePath = GetLocalFilePath(fileName);
+        _configuration = new ConfigurationBuilder()
+            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .Build();
     }
 
     private string GetLocalFilePath(string fileName)
@@ -26,7 +32,20 @@ public class SettingsManager<T> where T : class
         if (File.Exists(_filePath))
         {
             var json = File.ReadAllText(_filePath);
-            return JsonSerializer.Deserialize<T>(json);
+            var settings = JsonSerializer.Deserialize<T>(json);
+
+            // Load BattlefieldApiUrl from appsettings.json
+            var battlefieldApiUrl = _configuration["BattlefieldApiUrl"];
+            if (settings != null && !string.IsNullOrEmpty(battlefieldApiUrl))
+            {
+                var property = typeof(T).GetProperty("BattlefieldApiUrl");
+                if (property != null && property.CanWrite)
+                {
+                    property.SetValue(settings, battlefieldApiUrl);
+                }
+            }
+
+            return settings;
         }
 
         return null;

--- a/Phos.ScreenSync/UserSettings.cs
+++ b/Phos.ScreenSync/UserSettings.cs
@@ -4,4 +4,5 @@ public class UserSettings
 {
     public string WebSocketUrl { get; set; } = string.Empty;
     public string Battlefield4Username { get; set; } = string.Empty;
+    public string BattlefieldApiUrl { get; set; } = string.Empty;
 }

--- a/Phos.ScreenSync/UserSettings.cs
+++ b/Phos.ScreenSync/UserSettings.cs
@@ -3,4 +3,5 @@
 public class UserSettings
 {
     public string WebSocketUrl { get; set; } = string.Empty;
+    public string Battlefield4Username { get; set; } = string.Empty;
 }

--- a/Phos.ScreenSync/appsettings.json
+++ b/Phos.ScreenSync/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "BattlefieldApiUrl": "https://api.bflist.io/bf4/v1/players/"
+}


### PR DESCRIPTION
Related to #2

Add Battlefield 4 API integration to change LED color based on player status.

* Add a new "Battlefield 4" tab in the UI with a TextBox for inputting the Battlefield 4 username, a start/stop button for polling the API, and a readonly TextBox to display the formatted JSON output of the API call.
* Update `MainWindow.xaml.cs` to handle the input, start/stop button, and display the JSON output.
* Store and restore the Battlefield 4 username each time the application starts.
* Poll the Battlefield 4 API every 1 second when the user clicks start and stop when the user clicks stop.
* Turn the LED strip red for 1 second each time the user dies and then back to black.
* Add a property for the Battlefield 4 username in `UserSettings.cs`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Staijn1/phos-screensync/issues/2?shareId=a5708b33-954b-4737-b2bf-88881f1edab9).